### PR TITLE
Align headings to left on mobile

### DIFF
--- a/ui/text-box/text-box.js
+++ b/ui/text-box/text-box.js
@@ -2,7 +2,7 @@ import t from 'prop-types'
 import styled from 'styled-components'
 import { rgba } from 'polished'
 
-import { Link, BoldText } from 'ui'
+import { Link, BoldText, media } from 'ui'
 import { insertComponentsIntoText } from 'resources'
 
 export const components = {
@@ -53,7 +53,7 @@ const Title = styled.h3`
     background-color: ${({ theme }) => theme.colors.primary};
   }
 
-  ${({ invert }) => invert && `
+  ${({ invert }) => invert && media.greaterThan('md')`
     align-self: flex-end;
   `};
 `


### PR DESCRIPTION
Closes #2 

Essa PR alinha todos headings à esquerda no mobile:

![image](https://user-images.githubusercontent.com/38966428/94964427-2ecfa180-04d0-11eb-8fa3-c9d3c547c8dd.png)
